### PR TITLE
Investigate 404 page not found error

### DIFF
--- a/src/Routes.jsx
+++ b/src/Routes.jsx
@@ -19,7 +19,7 @@ const Routes = () => {
   const { user } = useAuth();
 
   return (
-    <BrowserRouter>
+    <BrowserRouter basename={import.meta.env.BASE_URL}>
       <ErrorBoundary>
       <ScrollToTop />
       <Suspense fallback={<SplashScreen message="Loading..." />}> 
@@ -76,6 +76,14 @@ const Routes = () => {
           element={
             <ProtectedRoute>
               <CareerBoard />
+            </ProtectedRoute>
+          } 
+        />
+        <Route 
+          path="/events-management" 
+          element={
+            <ProtectedRoute>
+              <EventsManagement />
             </ProtectedRoute>
           } 
         />


### PR DESCRIPTION
Add `/events-management` route and configure router basename to fix 404 errors.

The `/events-management` page was showing a 404 because its route was missing from `Routes.jsx`. Additionally, `BrowserRouter` was updated with `basename={import.meta.env.BASE_URL}` to ensure correct routing for sub-path deployments and deep links, preventing 404s on in-app navigation.

---
<a href="https://cursor.com/background-agent?bcId=bc-4a048fb6-bf3d-4a61-9f9f-9af0948f5ed9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4a048fb6-bf3d-4a61-9f9f-9af0948f5ed9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

